### PR TITLE
Proper propagation of verbose, limit_area and limit_direction and support for pandas series for domain features

### DIFF
--- a/hrvanalysis/extract_features.py
+++ b/hrvanalysis/extract_features.py
@@ -269,6 +269,10 @@ def get_frequency_domain_features(nn_intervals: List[float], method: str = WELCH
 
     """
 
+    # ----------  Handle pandas series  ---------- #
+
+    nn_intervals = list(nn_intervals)
+
     # ----------  Compute frequency & Power spectral density of signal  ---------- #
     freq, psd = _get_freq_psd_from_nn_intervals(nn_intervals=nn_intervals, method=method,
                                                 sampling_frequency=sampling_frequency,
@@ -276,12 +280,12 @@ def get_frequency_domain_features(nn_intervals: List[float], method: str = WELCH
                                                 vlf_band=vlf_band, hf_band=hf_band)
 
     # ---------- Features calculation ---------- #
-    freqency_domain_features = _get_features_from_psd(freq=freq, psd=psd,
+    frequency_domain_features = _get_features_from_psd(freq=freq, psd=psd,
                                                       vlf_band=vlf_band,
                                                       lf_band=lf_band,
                                                       hf_band=hf_band)
 
-    return freqency_domain_features
+    return frequency_domain_features
 
 
 def _get_freq_psd_from_nn_intervals(nn_intervals: List[float], method: str = WELCH_METHOD,

--- a/tests/tests_extract_features_methods.py
+++ b/tests/tests_extract_features_methods.py
@@ -4,9 +4,11 @@
 import os
 import unittest
 import numpy as np
+import pandas as pd
 from hrvanalysis.extract_features import (get_time_domain_features, get_geometrical_features,
                                           _create_interpolated_timestamp_list, get_sampen,
-                                          get_csi_cvi_features, get_poincare_plot_features)
+                                          get_csi_cvi_features, get_poincare_plot_features,
+                                          get_frequency_domain_features)
 
 
 TEST_DATA_FILENAME = os.path.join(os.path.dirname(__file__), 'test_nn_intervals.txt')
@@ -91,6 +93,16 @@ class ExtractFeaturesTestCase(unittest.TestCase):
         function_sampen_features = get_sampen(nn_intervals)
         sampen_plot_features = {'sampen': 1.2046675751816824}
         self.assertAlmostEqual(function_sampen_features, sampen_plot_features)
+
+    def test_if_get_frequency_domain_features_handles_pandas_series(self):
+
+        # TODO: Investigate: extract_features.py:432: RuntimeWarning: invalid value encountered in double_scalars
+        # Also occurs with list only.
+
+        try:
+            get_frequency_domain_features(pd.Series([42]*10000))
+        except KeyError:
+            self.fail()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dear all,

some small convenience and bug fixes:

- `verbose`was not correctly propagated when using `get_nn_intervals()`.
- In the same go I also allowed for setting `limit_direction='forward'` and `limit_area=None` from the outer scope. I used the defaults from [pandas.Series.interpolate](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.interpolate.html). Also I changed the limit, I didn't see why filling just 1 value is okay, but more is not. If you disagree on this, I can change this of course.
- All feature extraction methods went smoothly with pandas series, except `frequency_domain_features()`. Officially it takes a list, but with respect to duct-typing I allowed myself to add a cast to list to make it work, should be much of a performance issue, but adds convenience and saves some time finding the bug, when actually passing a pandas series.
- Added a unit test for the above points.
- Added TODO for a computational warning I found during testing.
- Fixed a typo within a function name.

Hope I didn't forgot to mention anything. If you want me to change something, let me know. All tests still pass.

Cheers
flennic